### PR TITLE
Fix Offcanvas context id and trigger props

### DIFF
--- a/src/app/components/OffCanvas/Context.tsx
+++ b/src/app/components/OffCanvas/Context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useReducer } from 'react'
+import React, { createContext, useReducer, useId } from 'react'
 import { ProviderProps } from './Props'
 
 type State = {
@@ -45,6 +45,9 @@ export function OffcanvasProvider({
         isOpen: false
     })
 
+    // generate a stable unique id for this provider instance
+    const id = useId()
+
     const handleOpen = () => {
         dispatch({ type: 'open' })
         if (onOpen) onOpen()
@@ -55,7 +58,7 @@ export function OffcanvasProvider({
     }
 
     return (
-        <AppContext.Provider value={{ isOpen, handleOpen, handleClose, randomId: "new" }}>
+        <AppContext.Provider value={{ isOpen, handleOpen, handleClose, randomId: id }}>
             <div className="simple-offcanvas-component d-flex align-items-center">{children}</div>
         </AppContext.Provider>
     )

--- a/src/app/components/OffCanvas/Trigger.tsx
+++ b/src/app/components/OffCanvas/Trigger.tsx
@@ -11,7 +11,18 @@ export function Trigger({
 }: TriggerProps) {
     const { handleOpen, randomId } = useContext(AppContext)
 
+    const Component = component as keyof JSX.IntrinsicElements
+
     return (
-        <Image width={50} height={50} src="/img/text-center.svg"  id="menu-ico" alt='Menu' onClick={handleOpen} />
+        <Component
+            className={className}
+            style={styles}
+            onClick={handleOpen}
+            aria-controls={`offcanvas_${randomId}`}
+        >
+            {children ? children : (
+                <Image width={50} height={50} src="/img/text-center.svg" id="menu-ico" alt="Menu" />
+            )}
+        </Component>
     )
 }


### PR DESCRIPTION
## Summary
- generate a unique id in `OffcanvasProvider`
- make the `Trigger` component respect props and show default icon

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: next: not found)*